### PR TITLE
darwin: add support for homebrew

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,20 @@
+var fs = require('fs')
+
 module.exports = null
 
-if (process.platform === 'darwin')
-  return module.exports = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+if (process.platform === 'darwin') {
+  var regPath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+  var altPath = '~' + regPath;
+
+  return module.exports = fs.existsSync(regPath)
+    ? regPath
+    : altPath
+}
+
 
 if (process.platform !== 'win32')
   return module.exports = require('which').sync('google-chrome')
 
-var fs = require('fs')
 
 var suffix = '\\Google\\Chrome\\Application\\chrome.exe';
 var prefixes = [


### PR DESCRIPTION
Homebrew installs into `~` rather than `/` by default. This patch should provide an appropriate fallback if Chrome isn't found in root.
