### PR TITLE
Replace OSX false positive with mdfind search

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,21 @@ if (other) {
   }
 } else
 if (osx) {
-  var regPath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+  var osxSuffix = '/Contents/MacOS/Google Chrome'
+  var regPath = '/Applications/Google Chrome.app' + osxSuffix
   var altPath = require('userhome')(regPath.slice(1))
+  var mdFindCmd = 'mdfind \'kMDItemDisplayName == "Google Chrome" && kMDItemKind == Application\''
 
-  module.exports = fs.existsSync(regPath)
-    ? regPath
-    : altPath
+  if (fs.existsSync(regPath)) {
+    module.exports = regPath
+  } else if (fs.existsSync(altPath)) {
+    module.exports = altPath
+  } else {
+    var foundPath = require('child_process').execSync(mdFindCmd, { encoding: 'utf8' })
+    module.exports = (foundPath) ? foundPath.trim() + osxSuffix : null
+  }
 } else {
-  var suffix = '\\Google\\Chrome\\Application\\chrome.exe';
+  var winSuffix = '\\Google\\Chrome\\Application\\chrome.exe';
   var prefixes = [
       process.env.LOCALAPPDATA
     , process.env.PROGRAMFILES
@@ -26,7 +33,7 @@ if (osx) {
   ]
 
   for (var i = 0; i < prefixes.length; i++) {
-    var exe = prefixes[i] + suffix
+    var exe = prefixes[i] + winSuffix
     if (fs.existsSync(exe)) {
       module.exports = exe
       break


### PR DESCRIPTION
The ternary at 17 was returning `altPath` even though that path wasn't actually verified as accurate. So on OSX if I had Chrome in a location that wasn't either `regPath` or `altPath`, I got `altPath` erroneously returned.

I tried to tidy this up by
- only returning `altPath` if that path work
- if `altPath` _doesn't_ work, trying to get an accurate path with an `mdfind` query (lifted from https://github.com/ekryski/launchpad/blob/master/lib/local/platform/macos.js)

With that in place I got a workable path even when I put Chrome in weird places.

I think the code itself is a little sloppy with its nested conditionals, but I didn't want to mess too much with the original style. If you want me to do something to clean up like move the platform checks into separate functions, I'm happy to.
